### PR TITLE
Fix release workflow bump version action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - run: npm test
       - name: Bump version
         id: bump_version
-        uses: phips28/gh-action-bump-version@v11
+        uses: phips28/gh-action-bump-version@v11.1.1
         with:
           tag-prefix: v
       - run: npm run build


### PR DESCRIPTION
## Summary
- fix release workflow: use phips28/gh-action-bump-version tag v11.1.1

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f0282b58832c833b2df62a141761